### PR TITLE
Fix Docker issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,12 @@
 # Vim doesn't like CRLF, even on Windows.
 *.vim text eol=lf
 
+# This allows autoconf/automake to work with the Linux subsystem
+*.m4 text eol=lf
+*.ac text eol=lf
+*.am text eol=lf
+bootstrap text eol=lf
+
 # This is Windows-specific and should always have CRLF, or
 # Visual Studio may misbehave.
 *.sln     text eol=crlf

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN install_packages \
     libtool \
     pkg-config \
     file \
-    git
+    git \
+    ca-certificates
 
 COPY / /lolremez/
 


### PR DESCRIPTION
Thanks for this really useful tool. I ran into a couple of minor issues on Windows when following the instructions for building a docker image:

- If your git isn't configured to preserve line endings (meaning `core.autocrlf` is set to `true`), `bootstrap` and `.ac`/`.am` files will be checked out with CRLF line endings resulting in the shell complaining about files not existing. This is fixed by enforcing LF line endings for these files in `.gitattributes`, which makes checking out "just work" regardless of the user's settings.
- If you run `docker build` after cloning the repo but before initializing git submodules, Docker will try to initialize submodules but fail with several messages about failing to validate server certificates. Installing the `ca-certificates` package fixes this.